### PR TITLE
Remove hard-coded v

### DIFF
--- a/train_burgers.py
+++ b/train_burgers.py
@@ -68,7 +68,7 @@ def test(config):
         ckpt = torch.load(ckpt_path)
         model.load_state_dict(ckpt['model'])
         print('Weights loaded from %s' % ckpt_path)
-    eval_burgers(model, dataloader, config, device)
+    eval_burgers(model, dataloader, dataset.v, config, device)
 
 
 if __name__ == '__main__':

--- a/train_burgers.py
+++ b/train_burgers.py
@@ -37,6 +37,7 @@ def run(args, config):
                                                      gamma=config['train']['scheduler_gamma'])
     train_2d_burger(model,
                     train_loader,
+                    dataset.v,
                     optimizer,
                     scheduler,
                     config,

--- a/train_utils/datasets.py
+++ b/train_utils/datasets.py
@@ -89,6 +89,7 @@ class BurgersLoader(object):
             self.T += 1
         self.x_data = dataloader.read_field('input')[:, ::sub]
         self.y_data = dataloader.read_field('output')[:, ::sub_t, ::sub]
+        self.v = dataloader.read_field('visc').item()
 
     def make_loader(self, n_sample, batch_size, start=0, train=True):
         Xs = self.x_data[start:start + n_sample]

--- a/train_utils/eval_2d.py
+++ b/train_utils/eval_2d.py
@@ -60,6 +60,7 @@ def eval_darcy(model,
 
 def eval_burgers(model,
                  dataloader,
+                 v,
                  config,
                  device,
                  use_tqdm=True):
@@ -78,7 +79,7 @@ def eval_burgers(model,
         out = model(x).reshape(y.shape)
         data_loss = myloss(out, y)
 
-        loss_u, f_loss = PINO_loss(out, x[:, 0, :, 0])
+        loss_u, f_loss = PINO_loss(out, x[:, 0, :, 0], v)
         test_err.append(data_loss.item())
         f_err.append(f_loss.item())
 

--- a/train_utils/losses.py
+++ b/train_utils/losses.py
@@ -198,7 +198,7 @@ class LpLoss(object):
         return self.rel(x, y)
 
 
-def FDM_Burgers(u, D=1, v=1/100):
+def FDM_Burgers(u, v, D=1):
     batchsize = u.size(0)
     nt = u.size(1)
     nx = u.size(2)
@@ -221,7 +221,7 @@ def FDM_Burgers(u, D=1, v=1/100):
     return Du
 
 
-def PINO_loss(u, u0):
+def PINO_loss(u, u0, v):
     batchsize = u.size(0)
     nt = u.size(1)
     nx = u.size(2)
@@ -234,7 +234,7 @@ def PINO_loss(u, u0):
     boundary_u = u[:, index_t, index_x]
     loss_u = F.mse_loss(boundary_u, u0)
 
-    Du = FDM_Burgers(u)[:, :, :]
+    Du = FDM_Burgers(u, v)[:, :, :]
     f = torch.zeros(Du.shape, device=u.device)
     loss_f = F.mse_loss(Du, f)
 

--- a/train_utils/train_2d.py
+++ b/train_utils/train_2d.py
@@ -117,7 +117,7 @@ def train_2d_operator(model,
 
 
 def train_2d_burger(model,
-                    train_loader,
+                    train_loader, v,
                     optimizer, scheduler,
                     config,
                     rank=0, log=False,
@@ -153,7 +153,7 @@ def train_2d_burger(model,
             out = model(x).reshape(y.shape)
             data_loss = myloss(out, y)
 
-            loss_u, loss_f = PINO_loss(out, x[:, 0, :, 0])
+            loss_u, loss_f = PINO_loss(out, x[:, 0, :, 0], v)
             total_loss = loss_u * ic_weight + loss_f * f_weight + data_loss * data_weight
 
             optimizer.zero_grad()


### PR DESCRIPTION
The hard-coded `v = 1/100` in `FDM_Burgers` would cause problems when the user runs PINO on new data generated with a different `v`.